### PR TITLE
Fix problems with tag links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,13 @@
 # Docs-Browser
 
 The Docs-Browser is used to view project documentation across multiple branches. This document is made available to test that the Docs-Browser works on itself.
+
+# Creating Docs
+
+The Docs-Browser searches the `docs` folder in project branches for instances of a document.  The naming conventions for documents is as follows:
+
+1. Only alphanumeric and underscore characters are allowed in document names.
+2. Document names must begin with an uppercase letter.  
+3. Spaces must be replaced by hyphens.
+
+

--- a/src/_page.html
+++ b/src/_page.html
@@ -20,20 +20,21 @@ function load_markdown(url)
             var re = /\[\[[-A-Za-z_ 0-9]+\]\]/g;
             function to_url(tag)
             {
-                ref = tag.substr(2,tag.length-4);
-                return "<A HREF=\"?owner=" + owner + "&project=" + project + "&branch=" + branch + "&doc=" + ref + ".md\">" + ref + "</A>";
+                tag = tag.substr(2,tag.length-4);
+                ref = (tag.charAt(0).toUpperCase() + tag.slice(1)).replace(' ','-');
+                return "<A HREF=\"" + location.origin + location.pathname + "?owner=" + owner + "&project=" + project + "&branch=" + branch + "&doc=" + ref + ".md\">" + tag + "</A>";
             }
             var ro = re[Symbol.replace](rr.responseText,to_url);
             document.writeln(ro);
         }
         else //if ( rr.status != 404 )
         {                
-            throw ('<FONT COLOR=RED>[ERROR ' + rr.status + ' ['+url+'] '+rr.responseText+'</FONT><BR/>');
+            throw ('<FONT COLOR=RED>ERROR ' + rr.status + ' ['+url+'] ' + rr.responseText + '</FONT><BR/>');
         }
     }
     else //if ( r.status != 404 )
     {
-        throw ('<FONT COLOR=RED>[ERROR ' + r.status + ' ['+url+'] '+r.responseText+'</FONT><BR/>');
+        throw ('<FONT COLOR=RED>ERROR ' + r.status + ' ['+url+'] ' + r.responseText + '</FONT><BR/>');
     }
 }    
 </SCRIPT>
@@ -74,9 +75,9 @@ Source document:
     {        
         load_markdown(base+doc);
     }
-    catch (err)
+    catch (msg)
     {
-        document.writeln("ERROR: "+err.message)
+        document.writeln("<FONT COLOR=RED>" + msg + "</FONT>");
     }
     document.writeln('</DIV>');
     document.writeln('<DIV ID="footer" CLASS="footer">')


### PR DESCRIPTION
This PR addresses issue #7.  The problem was that leading lowercase letter and spaces in tags were not being converted correctly to conform with the document naming convention.  In addition, the document naming convention was not documented.

# Current Issues
None

# Code Changes
1. Force first letter to uppercase.
2. Added replacement of spaces to hyphens in tags.
3. Minor code style and error handling fixes.

# Documentation Changes
1. Added a brief summary of where documents are located and what the naming convention is.

# Testing and Validation Tips
1. Open the local version of `index.html` with the query `project=gridlabd&owner=dchassin`.
2. Select the `Remote` page and attempt to link to `remote`. This should confirm that the leading uppercase letter is converted.
3. Select the 'JSON-input` page and attempt to link to `JSON output`. This should confirm that embedded spaces are converted to hyphens.