### PR TITLE
Cleanup of banner, copyright, etc.

### DIFF
--- a/src/_config.js
+++ b/src/_config.js
@@ -4,6 +4,13 @@
 // This module set the document specifications `host`, `owner`, `project`, `branch`, and `doc`
 // as given by the URL, or if absent, as given by the current defaults
 //
+var banner = '<A HREF="https://github.com/slacgismo/docs-browser" TARGET="_blank">SLAC GISMo Docs Browser</A>';
+var year = (new Date()).getFullYear();
+if ( year > 2019 )
+{
+    year = "2019-" + year;
+}
+var copyright = '<A HREF="https://raw.githubusercontent.com/slacgismo/docs-browser/master/LICENSE" TARGET="_blank">Copyright (C) ' + year + ', Regents of the Leland Stanford Junior University</A>';
 var query = new URLSearchParams(window.location.search);
 var host = query.get('host');
 if ( host == null )

--- a/src/_contents.html
+++ b/src/_contents.html
@@ -70,8 +70,8 @@
 <BODY>
 
 <TABLE WIDTH="100%">
-<CAPTION>SLAC GISMo Docs Browser</CAPTION>
 <SCRIPT LANGUAGE="JavaScript">
+    document.writeln("<CAPTION>" + banner + "</CAPTION>");
     var href = location.origin + location.pathname.replace('/_contents.html','/_page.html');
     document.writeln('<TR><TH ALIGN=LEFT>Host</TH><TD><INPUT ID="host" ONKEYDOWN="set_host()" NAME="host" VALUE="' + host + '" /></TD></TR>');
     document.writeln('<TR><TH ALIGN=LEFT>User/Org</TH><TD><INPUT ID="owner" ONKEYDOWN="set_owner()" NAME="owner" VALUE="' + owner + '" /></TD></TR>');
@@ -120,6 +120,11 @@
 </SCRIPT>
 </DIV>
 
+</DIV>
+<DIV CLASS="footer">
+<SCRIPT LANGUAGE="JavaScript">
+    document.writeln(copyright);
+</SCRIPT>
 </DIV>
 
 </BODY>

--- a/src/_page.html
+++ b/src/_page.html
@@ -43,9 +43,6 @@ function load_markdown(url)
 <BODY>
 
 <SCRIPT LANGUAGE="JavaScript">
-    var banner = "SLAC GISMo Docs Browser";
-    var now = new Date();
-    var copyright = "Copyright (C) " + now.getFullYear() + ", Regents of the Leland Stanford Junior University";
     var query = new URLSearchParams(window.location.search);
     var href = location.origin + location.pathname.substring(0,location.pathname.lastIndexOf('/')+1);
     // TODO: The replacement of <name>.com -> raw.<name>usercontent.com is probably not general, but works for github.com.
@@ -67,7 +64,6 @@ Source document:
     } 
     catch (e) 
     {
-        document.writeln(banner);
     }
     document.writeln('</DIV>');
     document.writeln('<DIV ID="page" CLASS="page">')
@@ -88,7 +84,6 @@ Source document:
     } 
     catch (e) 
     {
-        document.writeln(copyright);
     }
     document.writeln('</DIV>');
 </SCRIPT>

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
 <SCRIPT LANGUAGE="Javascript" SRC="_defaults.js"></SCRIPT>
 <SCRIPT LANGUAGE="Javascript" SRC="_config.js"></SCRIPT>
 <SCRIPT LANGUAGE="JavaScript">
-    page = "host=" + host + "&owner=" + owner + "&project=" + project + "&branch=" + branch + "&doc=" + doc;
+    var page = "host=" + host + "&owner=" + owner + "&project=" + project + "&branch=" + branch + "&doc=" + doc;
     document.writeln('<FRAMESET COLS="' + left_panel_width + ',*">');
     document.writeln('<FRAME SRC="_contents.html?' + page + '"/>');
     document.writeln('<FRAME NAME="page" SRC="_page.html?' + page + '" />');


### PR DESCRIPTION
This PR addresses some layout issues. Specifically, the page panel document is committed exclusively to the target page and left panel is exclusively for the docs-browser itself.  As a result the docs-browser copyright message is now placed under the TOC, leaving the target page footer to present the copyright (if any). The docs-browser banner is also removed from page layout, leaving exclusive room for the header (if any). Also, the copyright year is fixed so that it display a year range when necessary.