### PR TITLE
Add mathjax support

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,5 +17,5 @@ The following markdown extensions are supported.
 
 ## MathJax
 
-You may embed math inline using the `\(equation\)` syntax, and on a separate line using the `\[equation\]` syntax.  For example, when \(a \ne 0\), there are two solutions to \(ax^2 + bx + c = 0\) and they are
-  \[x = {-b \pm \sqrt{b^2-4ac} \over 2a}.\]
+You may embed math inline using the `\(equation\)` syntax, and on a separate line using the `\[equation\]` syntax.  For example, when \\(a \ne 0\\), there are two solutions to \\(ax^2 + bx + c = 0\\) and they are
+  \\[x = {-b \pm \sqrt{b^2-4ac} \over 2a}.\\]

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,18 +2,18 @@
 
 The Docs-Browser is used to view project documentation across multiple branches. This document is made available to test that the Docs-Browser works on itself.
 
-# Creating Docs
+# Creating Documents
 
-The Docs-Browser searches the `docs` folder in project branches for instances of a document.  The naming conventions for documents is as follows:
+The Docs-Browser searches the `docs` folder in project branches for markdown documents (i.e., with an `.md` extension).  The naming conventions for documents is as follows:
 
 1. Only alphanumeric and underscore characters are allowed in document names.
 2. Document names must begin with an uppercase letter.  
 3. Spaces must be replaced by hyphens.
 
 
-# Extensions
+# Markdown Extensions
 
-The following extensions are supported.
+The following markdown extensions are supported.
 
 ## MathJax
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,5 +17,5 @@ The following markdown extensions are supported.
 
 ## MathJax
 
-You may embed math inline using the `\(equation\)` syntax, and on a separate line using the `\[equation\]` syntax.  For example, when \\\(a \ne 0\\\), there are two solutions to \\\(ax^2 + bx + c = 0\\\) and they are
-  \\\[x = {-b \pm \sqrt{b^2-4ac} \over 2a}.\\\]
+You may embed math inline using the `\(equation\)` syntax, and on a separate line using the `\[equation\]` syntax.  For example, when \(a \ne 0\), there are two solutions to \(ax^2 + bx + c = 0\) and they are
+  \[x = {-b \pm \sqrt{b^2-4ac} \over 2a}.\]

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,3 +11,11 @@ The Docs-Browser searches the `docs` folder in project branches for instances of
 3. Spaces must be replaced by hyphens.
 
 
+# Extensions
+
+The following extensions are supported.
+
+## MathJax
+
+You may embed math inline using the `\(equation\)` syntax, and on a separate line using the `\[equation\]` syntax.  For example, when \(a \ne 0\), there are two solutions to \(ax^2 + bx + c = 0\) and they are
+  \[x = {-b \pm \sqrt{b^2-4ac} \over 2a}.\]

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,5 +17,5 @@ The following markdown extensions are supported.
 
 ## MathJax
 
-You may embed math inline using the `\(equation\)` syntax, and on a separate line using the `\[equation\]` syntax.  For example, when \\(a \ne 0\\), there are two solutions to \\(ax^2 + bx + c = 0\\) and they are
-  \\[x = {-b \pm \sqrt{b^2-4ac} \over 2a}.\\]
+You may embed math inline using the `\(equation\)` syntax, and on a separate line using the `\[equation\]` syntax.  For example, when \\\(a \ne 0\\\), there are two solutions to \\\(ax^2 + bx + c = 0\\\) and they are
+  \\\[x = {-b \pm \sqrt{b^2-4ac} \over 2a}.\\\]

--- a/src/_page.html
+++ b/src/_page.html
@@ -5,7 +5,7 @@
 <SCRIPT LANGUAGE="Javascript" SRC="_defaults.js"></SCRIPT>
 <SCRIPT LANGUAGE="Javascript" SRC="_config.js"></SCRIPT>
 <SCRIPT SRC="https://polyfill.io/v3/polyfill.min.js?features=es6"></SCRIPT>
-<SCRIPT ID="MathJax-script" ASYNC SRC="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></SCRIPT>
+<SCRIPT ID="MathJax-script" SRC="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></SCRIPT>
 <SCRIPT LANGUAGE="JavaScript">
 function load_markdown(url)
 {
@@ -33,6 +33,9 @@ function load_markdown(url)
         {                
             throw ('<FONT COLOR=RED>ERROR ' + rr.status + ' ['+url+'] ' + rr.responseText + '</FONT><BR/>');
         }
+        MathJax.startup.document.state(0);
+        MathJax.texReset();
+        MathJax.typeset();
     }
     else //if ( r.status != 404 )
     {

--- a/src/_page.html
+++ b/src/_page.html
@@ -4,6 +4,8 @@
 <LINK rel="stylesheet" type="text/css" href="_theme.css" />
 <SCRIPT LANGUAGE="Javascript" SRC="_defaults.js"></SCRIPT>
 <SCRIPT LANGUAGE="Javascript" SRC="_config.js"></SCRIPT>
+<SCRIPT SRC="https://polyfill.io/v3/polyfill.min.js?features=es6"></SCRIPT>
+<SCRIPT ID="MathJax-script" ASYNC SRC="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></SCRIPT>
 <SCRIPT LANGUAGE="JavaScript">
 function load_markdown(url)
 {


### PR DESCRIPTION
This PR addresses issue #11.

# Current issues
1. It doesn't actually work.
2. The ASYNC capability is not included.

# Code changes
1. Added js script calls per docs.mathjax.org

# Documentation changes
1. Add extensions section in README.md

# Validation suggestions
1. Go to README.md and view the new section on extensions.